### PR TITLE
feat: Enhance CreateUserValidator with role-specific validation for guests and staff

### DIFF
--- a/src/pages/admin/UserManagement.tsx
+++ b/src/pages/admin/UserManagement.tsx
@@ -1275,6 +1275,9 @@ export default function UserManagement() {
                   status: form.status,
                   district_id: form.district_id,
                   community_id: form.community_id,
+                  password: form.password,
+                  confirmPassword: form.confirmPassword,
+                  access_expires_at: form.access_expires_at,
                 }}
                 isVisible={showValidator}
                 onToggleVisibility={() => setShowValidator(!showValidator)}


### PR DESCRIPTION
This pull request improves the `CreateUserValidator` component by adding role-specific validation for user creation, especially for guest and staff/admin users. The main enhancements include new checks for guest access expiry and more comprehensive password validation for staff/admin roles. Additionally, the form data structure and usage have been updated to support these new validations.

**Validation logic improvements:**

* Added a check to ensure that guests have an `access_expires_at` date, and that the date is in the future.
* Enhanced password validation for staff/admin roles to require a password, enforce a minimum length, and check that password and confirm password fields match.

**Form data structure updates:**

* Extended the `FormData` interface to include `password`, `confirmPassword`, and `access_expires_at` fields for role-specific validation.
* Updated the `UserManagement` page and `CreateUserValidator` usage to pass the new fields (`password`, `confirmPassword`, `access_expires_at`) from the form data. [[1]](diffhunk://#diff-f86fca1832bd934b6dbebc3b9be6153d789d44bff256b1081b45aa187945cb2dR1278-R1280) [[2]](diffhunk://#diff-e254470e01a75839d0e78a4fb1f3723758353ffbdb45ba706ba27b426e1b9d4eR245)